### PR TITLE
#98 accept arbitrary entry points for UI

### DIFF
--- a/edu.cuny.hunter.streamrefactoring.core/src/edu/cuny/hunter/streamrefactoring/core/analysis/Stream.java
+++ b/edu.cuny.hunter.streamrefactoring.core/src/edu/cuny/hunter/streamrefactoring/core/analysis/Stream.java
@@ -53,7 +53,6 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.CallGraphBuilderCancelException;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
-import com.ibm.wala.ipa.callgraph.impl.DefaultEntrypoint;
 import com.ibm.wala.ipa.callgraph.impl.FakeRootMethod;
 import com.ibm.wala.ipa.callgraph.impl.FakeWorldClinitMethod;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -171,7 +170,7 @@ public class Stream {
 	private PreconditionSuccess passingPrecondition;
 
 	public Stream(MethodInvocation streamCreation) throws ClassHierarchyException, IOException, CoreException,
-			InvalidClassFileException, CallGraphBuilderCancelException, CancelException {
+			InvalidClassFileException, CallGraphBuilderCancelException, CancelException, noEntryPointException {
 		this.creation = streamCreation;
 		this.enclosingTypeDeclaration = (TypeDeclaration) ASTNodes.getParent(this.getCreation(),
 				ASTNode.TYPE_DECLARATION);
@@ -576,7 +575,7 @@ public class Stream {
 	private void inferInitialOrdering()
 			throws IOException, CoreException, ClassHierarchyException, InvalidClassFileException,
 			InconsistentPossibleOrderingException, NoniterableException, NoninstantiableException,
-			CannotExtractSpliteratorException, CallGraphBuilderCancelException, CancelException {
+			CannotExtractSpliteratorException, CallGraphBuilderCancelException, CancelException, noEntryPointException {
 		ITypeBinding expressionTypeBinding = this.getCreation().getExpression().resolveTypeBinding();
 		String expressionTypeQualifiedName = expressionTypeBinding.getErasure().getQualifiedName();
 		IMethodBinding calledMethodBinding = this.getCreation().resolveMethodBinding();
@@ -772,14 +771,13 @@ public class Stream {
 	protected OrderingInference getOrderingInference() {
 		return orderingInference;
 	}
-
+	
 	protected void buildCallGraph()
-			throws IOException, CoreException, CallGraphBuilderCancelException, CancelException {
+			throws IOException, CoreException, CallGraphBuilderCancelException, CancelException, noEntryPointException {
 		if (!this.isCallGraphBuilt()) {
 			// FIXME: Do we want a different entry point?
 			// TODO: Do we need to build the call graph for each stream?
-			DefaultEntrypoint entryPoint = new DefaultEntrypoint(getEnclosingMethodReference(), getClassHierarchy());
-			Set<Entrypoint> entryPoints = Collections.singleton(entryPoint);
+			Set<Entrypoint> entryPoints = Util.findEntryPoints(getAnalysisEngine().getClassHierarchy());
 
 			// set options.
 			AnalysisOptions options = getAnalysisEngine().getDefaultOptions(entryPoints);

--- a/edu.cuny.hunter.streamrefactoring.core/src/edu/cuny/hunter/streamrefactoring/core/analysis/StreamAnalysisVisitor.java
+++ b/edu.cuny.hunter.streamrefactoring.core/src/edu/cuny/hunter/streamrefactoring/core/analysis/StreamAnalysisVisitor.java
@@ -60,7 +60,7 @@ public class StreamAnalysisVisitor extends ASTVisitor {
 			try {
 				stream = new Stream(node);
 			} catch (ClassHierarchyException | IOException | CoreException | InvalidClassFileException
-					| CancelException e) {
+					| CancelException | noEntryPointException e) {
 				logger.log(Level.SEVERE, "Encountered exception while processing: " + node, e);
 				throw new RuntimeException(e);
 			}

--- a/edu.cuny.hunter.streamrefactoring.core/src/edu/cuny/hunter/streamrefactoring/core/analysis/noEntryPointException.java
+++ b/edu.cuny.hunter.streamrefactoring.core/src/edu/cuny/hunter/streamrefactoring/core/analysis/noEntryPointException.java
@@ -1,0 +1,8 @@
+package edu.cuny.hunter.streamrefactoring.core.analysis;
+
+public class noEntryPointException extends Exception {
+	
+	public noEntryPointException(String string) {
+		super(string);
+	}
+}

--- a/edu.cuny.hunter.streamrefactoring.core/src/edu/cuny/hunter/streamrefactoring/core/utils/Util.java
+++ b/edu.cuny.hunter.streamrefactoring.core/src/edu/cuny/hunter/streamrefactoring/core/utils/Util.java
@@ -3,7 +3,9 @@
  */
 package edu.cuny.hunter.streamrefactoring.core.utils;
 
+import java.util.Iterator;
 import java.util.Optional;
+import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -24,7 +26,18 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.participants.ProcessorBasedRefactoring;
 import org.eclipse.ltk.core.refactoring.participants.RefactoringProcessor;
 
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.ShrikeCTMethod;
+import com.ibm.wala.ipa.callgraph.Entrypoint;
+import com.ibm.wala.ipa.callgraph.impl.DefaultEntrypoint;
+import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.types.TypeName;
+import com.ibm.wala.types.annotations.Annotation;
+import com.ibm.wala.util.collections.HashSetFactory;
+
+import edu.cuny.hunter.streamrefactoring.core.analysis.noEntryPointException;
 import edu.cuny.hunter.streamrefactoring.core.refactorings.ConvertToParallelStreamRefactoringProcessor;
+import edu.cuny.hunter.streamrefactoring.core.wala.AnalysisUtils;
 
 /**
  * @author <a href="mailto:raffi.khatchadourian@hunter.cuny.edu">Raffi
@@ -148,4 +161,51 @@ public final class Util {
 		sb.append(")");
 		return sb.toString();
 	}
+	
+	/**
+	 * check whether the annotation is "EntryPoint"
+	 */
+	private static boolean isEntryPointClass(TypeName typeName) {
+		return typeName.getClassName().toString().equals("EntryPoint");
+	}
+
+	/**
+	 * Find all annotations in test cases
+	 * and check whether they are "entry point".
+	 * If yes, call DefaultEntrypoint to get entry point, 
+	 * then, add it into the result set.
+	 */
+	public static Set<Entrypoint> findEntryPoints(IClassHierarchy classHierarchy) throws noEntryPointException {
+		final Set<Entrypoint> result = HashSetFactory.make();
+		Iterator<IClass> classIterator = classHierarchy.iterator();
+		while (classIterator.hasNext()) {
+			IClass klass = classIterator.next();
+			if (!AnalysisUtils.isJDKClass(klass)) {
+
+				// iterate over all declared methods
+				for (com.ibm.wala.classLoader.IMethod method : klass.getDeclaredMethods()) {
+					try {
+						if (!(method instanceof ShrikeCTMethod)) {
+							throw new RuntimeException("@EntryPoint only works for byte code.");
+						}
+						// if method has an annotation
+						for (Annotation annotation : ((ShrikeCTMethod) method).getAnnotations(true)) {
+							if (isEntryPointClass(annotation.getType().getName())) {
+								result.add(new DefaultEntrypoint(method, classHierarchy));
+								break;
+							}
+						}
+					} catch (Exception e) {
+						throw new RuntimeException(e);
+					}
+				}
+			}
+		}
+		
+		//if there is no annotation "EntryPoint", then, throw an exception.
+		if (result.isEmpty())
+			throw new noEntryPointException("Need entry point.");
+		return result;
+	}
+	
 }


### PR DESCRIPTION
The current update can accept arbitrary entry points for UI.

1. To do: fix plug-in test. 

Plug-in test cannot work now. Because the compiles method only compiles one class file, but it also needs to compile another file EntryPoint.java.

2. To do: 

If there is no entry point, the project will throw an exception (I call it noEntryPointException). However, the testing cases should pass although this exception is thrown.

3. To do:

Finish second part. The project can recognize more than one entry points but it cannot handle them now.
