### PR TITLE
Delete unneeded values

### DIFF
--- a/edu.cuny.hunter.streamrefactoring.core/src/edu/cuny/hunter/streamrefactoring/core/analysis/StreamAnalyzer.java
+++ b/edu.cuny.hunter.streamrefactoring.core/src/edu/cuny/hunter/streamrefactoring/core/analysis/StreamAnalyzer.java
@@ -57,7 +57,7 @@ public class StreamAnalyzer extends ASTVisitor {
 
 	private boolean findImplicitBenchmarkEntryPoints;
 
-	private boolean findImplicitEntryPoints = true;
+	private boolean findImplicitEntryPoints;
 
 	private boolean findImplicitTestEntryPoints;
 


### PR DESCRIPTION
If the `findImplicitEntryPoints` is initialized, the option of `environment values` cannot work.